### PR TITLE
added const exec for builtin

### DIFF
--- a/include/exec.h
+++ b/include/exec.h
@@ -59,5 +59,6 @@ int		redirect_handler(t_node *node, int *in_fd, int *out_fd);
 void	perror_exit(char *message, int exit_status);
 
 void	free_exec(t_exec *exec);
+void	construct_bi_exec(t_exec *exec, t_node *node, t_config *config);
 
 #endif

--- a/src/exec/exec_command.c
+++ b/src/exec/exec_command.c
@@ -13,7 +13,7 @@
 #include "../../include/exec.h"
 
 static void	set_fd(t_node *node, t_exec *exec);
-static void	constuct_exec(t_exec *exec, t_node *node, t_config *config);
+static void	construct_exec(t_exec *exec, t_node *node, t_config *config);
 static void	exec_errors(t_exec *exec);
 
 int	exec_command(t_node *node, int in_fd, int out_fd, t_config *config)
@@ -23,15 +23,18 @@ int	exec_command(t_node *node, int in_fd, int out_fd, t_config *config)
 	exec.in_fd = in_fd;
 	exec.out_fd = out_fd;
 	exec.command = NULL;
-	constuct_exec(&exec, node, config);
 	if (!is_builtin_fxn(node))
 	{
+		construct_exec(&exec, node, config);
 		execve(exec.command, exec.argv, exec.envp);
 		exec_errors(&exec);
 		return (EXIT_FAILURE);
 	}
 	else
 	{
+		construct_bi_exec(&exec, node, config);
+		if(config->exit_status != EXIT_SUCCESS)
+			return (config->exit_status);
 		exec_bi_command(exec, config);
 		free_exec(&exec);
 		return (config->exit_status);
@@ -59,7 +62,7 @@ static void	exec_errors(t_exec *exec)
 	exit(126);
 }
 
-static void	constuct_exec(t_exec *exec, t_node *node, t_config *config)
+static void	construct_exec(t_exec *exec, t_node *node, t_config *config)
 {
 	int	i;
 

--- a/src/exec/exec_command_bi.c
+++ b/src/exec/exec_command_bi.c
@@ -1,0 +1,60 @@
+#include "../../include/exec.h"
+
+static void	set_bi_fd(t_node *node, t_exec *exec, t_config *config);
+
+void	construct_bi_exec(t_exec *exec, t_node *node, t_config *config)
+{
+	int	i;
+
+	set_bi_fd(node, exec, config);
+	if (!node->command)
+		config->exit_status = EXIT_SUCCESS;
+	set_builtin_path(exec, node);
+	if (!exec->command)
+		exec->command = get_path(node->command);
+	exec->argv = ft_calloc(node->arg_num + 2, sizeof(char *));
+	if (!exec->argv)
+	{
+		config->exit_status = EXIT_FAILURE;
+		perror("malloc");
+	}
+	exec->argv[0] = ft_strdup(exec->command);
+	i = -1;
+	while (++i < node->arg_num)
+		exec->argv[i + 1] = ft_strdup(node->argv[i]);
+	exec->argv[node->arg_num + 1] = NULL;
+	exec->envp = NULL;
+	if (config->envp_num > 0)
+	{
+		exec->envp = make_envp(config);
+		if (!exec->envp)
+		{
+			config->exit_status = EXIT_FAILURE;
+			perror("malloc");
+		}
+	}
+}
+
+static void	set_bi_fd(t_node *node, t_exec *exec, t_config *config)
+{
+	if (redirect_handler(node, &exec->in_fd, &exec->out_fd))
+		config->exit_status = EXIT_FAILURE;
+	if (exec->in_fd != 0)
+	{
+		if (dup2(exec->in_fd, 0) == -1)
+		{
+			config->exit_status = EXIT_FAILURE;
+			perror("dup2");
+		}
+		close(exec->in_fd);
+	}
+	if (exec->out_fd != 1)
+	{
+		if (dup2(exec->out_fd, 1) == -1)
+		{
+			config->exit_status = EXIT_FAILURE;
+			perror("dup2");
+		}
+		close(exec->out_fd);
+	}
+}


### PR DESCRIPTION
construct_execがbuiltinの実行時に実行されると、親プロセスでexitしてしまうため、config->exit_statusのみアップーとするように変更。以下二つの関数を作成、construct_exec, construct_bi_execの呼び出しをis_builtin_fxnのチェック後に行うようにした。
- construct_bi_exec
- sed_bi_fd